### PR TITLE
Fix outdated intranet links

### DIFF
--- a/content/markdown/en/04_02_organisation.md
+++ b/content/markdown/en/04_02_organisation.md
@@ -12,4 +12,4 @@ We make the infrastructure created in these projects available to all humanities
 
 DI employs almost 30 people. Besides a director and a small staff for planning, consultancy and communication, most of the colleagues work in six areas of expertise: [Infrastructure Services](infrastructure-services-en.html), [Structured Data](structured-data-en.html), [Text Analysis](text-analysis-en.html), [Computer vision](computer-vision-en.html), [Spatial Computing](spatial-computing-en.html) and [Interface Design](interface-design-en.html). One team focuses on managing the infrastructure, software and data. The other teams build software and therefore consist entirely of software engineers. Each engineer has a unique specialisation in addition to extensive experience of working in humanities research.
 
-See also : [Working with DI](working-for-di-en.html) and our [Intranet](https://intranet.huc.knaw.nl/nl/digitale-infrastructuur-0) (login required)
+See also : [Working with DI](working-for-di-en.html) and our [Intranet](https://communicatie.huc.knaw.nl/en/organisation/about-digital-infrastruture) (login required)

--- a/content/markdown/nl/04_02_De-afdeling.md
+++ b/content/markdown/nl/04_02_De-afdeling.md
@@ -13,4 +13,4 @@ De in projecten gerealiseerde infrastructuur maken we beschikbaar voor alle gees
 
 Bij DI werken bijna 30 personen. Naast een directeur en een kleine staf voor planning, consultancy en communicatie, werken de meeste collega’s verdeeld over zes expertise gebieden: [Infrastructuur Diensten](infrastructuur-diensten-nl.html), [Gestructureerde en Linked Data](gestructureerde-data-nl.html.html), [Tekstanalyse](tekstanalyse-nl.html), [Beeldverwerking](beeldverwerking-nl.html), [Gegrafische Analyse](geografische-analyse-nl.html) en [Interface design](interface-design-nl.html). Eén team focust op het beheer van de infrastructuur, software en data. De andere teams bouwen software en bestaan dus volledig uit software engineers. Elke engineer heeft naast ruime ervaring met het werken in geesteswetenschappelijk onderzoek ook een unieke specialisatie.
 
-Zie ook : [Werken bij DI](werken-bij-di-nl.html) en [Intranet](https://intranet.huc.knaw.nl/nl/digitale-infrastructuur-0) (login verplicht)
+Zie ook : [Werken bij DI](werken-bij-di-nl.html) en [Intranet](https://communicatie.huc.knaw.nl/nl/organisaties/digitale-infrastructuur/digital-infrastructure) (login verplicht)


### PR DESCRIPTION
This pull request fixes the outdated intranet links on the following pages:
[https://di.huc.knaw.nl/organisation-en.html](https://di.huc.knaw.nl/organisation-en.html)
[https://di.huc.knaw.nl/de-afdeling-nl.html](https://di.huc.knaw.nl/de-afdeling-nl.html)